### PR TITLE
feat(shoutbox): Use isolation

### DIFF
--- a/lib/personal_site/application.ex
+++ b/lib/personal_site/application.ex
@@ -9,6 +9,30 @@ defmodule PersonalSite.Application do
   def start(_type, _args) do
     redis_env = redis_env()
 
+    shoutbox_children = [
+      {
+        Redix,
+        {
+          redis_env[:url],
+          Keyword.merge(
+            redis_env[:opts],
+            name: PersonalSite.Redis.name(),
+            sync_connect: true,
+            exit_on_disconnection: true
+          )
+        }
+      },
+      # Start after the Redix supervisor
+      {PersonalSite.Shoutbox, []}
+    ]
+
+    isolated_shoutbox_supervisor = %{
+      # "Total" since it encompasses the totality of what's needed for the shoutbox
+      id: TotalShoutboxSupervisor,
+      type: :supervisor,
+      start: {Supervisor, :start_link, [shoutbox_children, [strategy: :rest_for_one]]}
+    }
+
     children = [
       # Start the Telemetry supervisor
       PersonalSiteWeb.Telemetry,
@@ -17,18 +41,7 @@ defmodule PersonalSite.Application do
       # Start the Endpoint (http/https)
       PersonalSiteWeb.Endpoint,
       PersonalSiteWeb.Presence,
-      {
-        Redix,
-        {
-          redis_env[:url],
-          Keyword.merge(
-            redis_env[:opts],
-            name: PersonalSite.Redis.name()
-          )
-        }
-      },
-      # Start after the Redix supervisor
-      {PersonalSite.Shoutbox, []}
+      isolated_shoutbox_supervisor
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
Based on the official guide [1][2] on handling reconnections.

This also resolves a similar issue during tests where Redis exits at an
inopportune time.

[1] https://hexdocs.pm/redix/reconnections.html#if-redis-is-vital-to-your-application
[2] Copied on 2024-05-06:

If Redis is vital to your application

You should use `sync_connect: true` if Redis is a vital part of your application: for example, if you plan to use a Redix process under your application's supervision tree, placed before the parts of your application that depend on it in the tree (so that this way, the application won't be started until a connection to Redis has been established). With `sync_connect: true`, disconnections after the TCP connection has been established will behave exactly as above (with reconnection attempts at given intervals). However, if your application can't function properly without Redix, then you want to use `exit_on_disconnection: true`. With this option, the connection will crash when a disconnection happens. With ``:sync_connect`` and ``:exit_on_disconnection``, you can isolate the part of your application that can't work without Redis under a supervisor and bring that part down when Redix crashes:

````
isolated_children = [
  {Redix, sync_connect: true, exit_on_disconnection: true},
  MyApp.MyGenServer
]

isolated_supervisor = %{
  id: MyChildSupervisor,
  type: :supervisor,
  start: {Supervisor, :start_link, [isolated_children, [strategy: :rest_for_one]]},
}

children = [
  MyApp.Child1,
  isolated_supervisor,
  MyApp.Child2
]

Supervisor.start_link(children, strategy: :one_for_one)
````
